### PR TITLE
Cleanup services as well before exit

### DIFF
--- a/knb
+++ b/knb
@@ -1046,7 +1046,7 @@ spec:
       name: udp
 EOF
 
-RESSOURCE_TO_CLEAN_BEFORE_EXIT="$RESSOURCE_TO_CLEAN_BEFORE_EXIT pod/$SERVER_POD_NAME"
+RESSOURCE_TO_CLEAN_BEFORE_EXIT="$RESSOURCE_TO_CLEAN_BEFORE_EXIT pod/$SERVER_POD_NAME svc/$SERVER_SERVICE_NAME"
 
 info "Waiting for server to be running"
 kubectl wait $NAMESPACEOPT --for=condition=Ready pod/$SERVER_POD_NAME --timeout=${POD_WAIT_TIMEOUT}s >/dev/null \


### PR DESCRIPTION
Noticed that knb-server-# services were being left behind after each knb run.
Include them in the list of resources to cleanup on exit

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>