### PR TITLE
Change to use an IP address to connect to the Service

### DIFF
--- a/knb
+++ b/knb
@@ -1149,6 +1149,8 @@ kubectl wait $NAMESPACEOPT --for=condition=Ready pod/$SERVER_POD_NAME --timeout=
 
 SERVER_IP=$(kubectl get $NAMESPACEOPT pod $SERVER_POD_NAME -o jsonpath={.status.podIP})
 $DEBUG && debug "Server IP address is $SERVER_IP"
+SERVICE_IP=$(kubectl get $NAMESPACEOPT svc $SERVER_SERVICE_NAME -o jsonpath={.spec.clusterIP})
+$DEBUG && debug "Service IP address is $SERVICE_IP"
 
 #==============================================================================
 # Data Detection
@@ -1217,14 +1219,14 @@ fi
 
 if [ "$CLIENT_TCP_P2S_POD_NAME" != "" ]
 then
-	run-client $CLIENT_TCP_P2S_POD_NAME $SERVER_SERVICE_NAME tcp
+	run-client $CLIENT_TCP_P2S_POD_NAME $SERVICE_IP tcp
 else
 	info "Skipping P2S TCP test"
 fi
 
 if [ "$CLIENT_UDP_P2S_POD_NAME" != "" ]
 then
-	run-client $CLIENT_UDP_P2S_POD_NAME $SERVER_SERVICE_NAME udp
+	run-client $CLIENT_UDP_P2S_POD_NAME $SERVICE_IP udp
 else
 	info "Skipping P2S UDP test"
 fi


### PR DESCRIPTION
Currently the code uses an IP address to establish a connection
between a Pod and another Pod (p2p), and uses a Service DNS name to establish
connection between a Pod and a Service (p2s).

This commit unifies behavior between p2p and p2s communication by using only
IP addresses in both cases.

Related to: #10